### PR TITLE
cicd: goreleaser to skip the build step

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,3 @@
+# .goreleaser.yaml
+builds:
+  - skip: true


### PR DESCRIPTION
As this is a library, no binary can be built, only consumers of the library result in their binary being built.