### PR TITLE
cicd: modernize lint workflow for Go 1.25 toolchain

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -24,13 +24,12 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs: conventional-commits
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.22.4'
-          check-latest: true
+          go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
   test:
@@ -38,9 +37,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs: lint
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.22.4'
-          check-latest: true
-      - run: go test -v -cover
+          go-version-file: go.mod
+      - run: go test -v -cover ./...


### PR DESCRIPTION
## Problem

PR #20 (dependabot: kin-openapi `0.133.0` → `0.139.0`) fails its **Lint files** check, which skips the test job (`needs: lint`):

```
can't load config: the Go language version (go1.24) used to build golangci-lint
is lower than the targeted Go version (1.25)
```

kin-openapi 0.139.0 requires Go 1.25, so the bump moves go.mod's directive to `go 1.25`. But `golangci/golangci-lint-action@v3` resolves `version: latest` to golangci-lint **v1.64.8**, a binary built with **go1.24**, which refuses to lint a module targeting a higher Go version. This breaks *any* PR that raises the go directive to 1.25 — not just #20.

The dependency bump itself is fine: `go build`, `go test`, and golangci-lint **v2** all pass locally on Go 1.25.4 with `0 issues`.

## Fix

- **`golangci-lint-action@v3 → v9`** — the actual fix. v9 ships a prebuilt golangci-lint v2 binary built with current Go, so it lints `go 1.25` modules.
- `checkout@v4 → v5`, `setup-go@v5 → v6` — clears Node 20 deprecation warnings.
- Replace hardcoded `go-version: '1.22.4'` (also stale/below go.mod) with `go-version-file: go.mod` so the toolchain tracks the module automatically.
- Add `./...` to the test command.

Once merged, dependabot PR #20 can be rebased and will go green.

## Verification

Locally on Go 1.25.4 against the #20 branch (kin-openapi 0.139.0):
- `go build ./...` ✓
- `go test ./...` → `ok`
- `golangci-lint run ./...` (v2.12.2) → `0 issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)