### PR TITLE
fix: replace deprecated parser.ParseDir with direct AST walk

### DIFF
--- a/openapi_godoc.go
+++ b/openapi_godoc.go
@@ -7,10 +7,11 @@ package openapigodoc
 import (
 	"encoding/json"
 	"fmt"
-	"go/doc"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -71,6 +72,66 @@ func walk() ([]string, error) {
 	return dirs, err
 }
 
+// docComment pairs a declaration's name with its doc comment text.
+type docComment struct {
+	name string
+	text string
+}
+
+// docComments parses every Go file in a single directory (non-recursively) and
+// returns the doc comments attached to exported types and to every exported
+// function or method (regardless of its receiver type's visibility) — the
+// declarations that may carry an @openapi annotation. It reads the AST
+// directly, replacing the parser.ParseDir/doc.New pair (both deprecated as of
+// Go 1.25) while still covering declarations in _test.go files, which
+// doc.NewFromFiles would otherwise skip.
+func docComments(path string) ([]docComment, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	var comments []docComment
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(path, entry.Name()), nil, parser.ParseComments)
+		if err != nil {
+			return nil, err
+		}
+		for _, decl := range f.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Name.IsExported() && d.Doc != nil {
+					comments = append(comments, docComment{d.Name.Name, d.Doc.Text()})
+				}
+			case *ast.GenDecl:
+				if d.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range d.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok || !ts.Name.IsExported() {
+						continue
+					}
+					// The doc comment attaches to the spec for grouped
+					// declarations and to the GenDecl for single ones.
+					group := ts.Doc
+					if group == nil {
+						group = d.Doc
+					}
+					if group != nil {
+						comments = append(comments, docComment{ts.Name.Name, group.Text()})
+					}
+				}
+			}
+		}
+	}
+	return comments, nil
+}
+
 // parseAndMergeComment parses a comment to extract OpenAPI definitions and merges it with an input definition
 func parseAndMergeComment(definition []byte, comment string) ([]byte, error) {
 	firstWord := strings.Split(comment, "\n")[0]
@@ -101,33 +162,15 @@ func generate(definition OpenAPIDefinition, validate bool) ([]byte, error) {
 	}
 
 	for _, path := range dirs {
-		fset := token.NewFileSet()
-		d, err := parser.ParseDir(fset, path, nil, parser.ParseComments)
+		comments, err := docComments(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed parse documentation at path %s: %w", path, err)
 		}
 
-		for _, f := range d {
-			p := doc.New(f, "./", 2)
-
-			for _, t := range p.Types {
-				apiDefinition, err = parseAndMergeComment(apiDefinition, t.Doc)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse OpenApi defnition for struct %s into OpenApi document: %w", t.Name, err)
-				}
-				for _, m := range t.Methods {
-					apiDefinition, err = parseAndMergeComment(apiDefinition, m.Doc)
-					if err != nil {
-						return nil, fmt.Errorf("failed to parse OpenApi defnition for method %s of struct %s into OpenApi document: %w", m.Name, t.Name, err)
-					}
-				}
-			}
-
-			for _, f := range p.Funcs {
-				apiDefinition, err = parseAndMergeComment(apiDefinition, f.Doc)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse OpenApi defnition for func %s into OpenApi document: %w", f.Name, err)
-				}
+		for _, c := range comments {
+			apiDefinition, err = parseAndMergeComment(apiDefinition, c.text)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse OpenApi defnition for %s into OpenApi document: %w", c.name, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

With the CI toolchain fixed (#21), dependabot PR #20 still fails lint — but now on a **real** code issue that the old linter couldn't even reach:

```
openapi_godoc.go:105:13: SA1019: parser.ParseDir has been deprecated since Go 1.25 ...
use golang.org/x/tools/go/packages (staticcheck)
```

`go/parser.ParseDir` (and the `go/ast.Package` it returns) were deprecated in **Go 1.25** — exactly the version PR #20 bumps `go.mod` to. So the bump legitimately surfaces it.

## Fix

Extract `@openapi` doc comments directly from the AST with `parser.ParseFile`, dropping `go/doc` entirely.

The deprecation notice suggests `doc.NewFromFiles`, but that **excludes `_test.go` declarations** (it mines them only for examples). This package's own `TestGenerate` fixtures (`Message`, `ErrorResponse`, `SayHello`) live in `openapi_godoc_test.go`, so switching to `doc.NewFromFiles` silently produces an empty document. Walking the AST directly preserves the original behaviour — documenting exported types, their methods, and functions across **all** `.go` files, test files included.

No new deprecated APIs are introduced (`parser.ParseFile`, `os.ReadDir`, `go/ast`, `go/token` are all current).

## Verification

Locally with `go.mod` set to `go 1.25` (Go 1.25.10):
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -v -cover ./...` → all 4 tests **PASS**, coverage 71.6% → **89.0%**
- `gofmt -l` clean

Note: the `parser.ParseDir` call is removed entirely, so the SA1019 finding cannot recur. Final confirmation comes from CI once #20 is rebased onto main (this branch is `go 1.23.3`, where staticcheck doesn't gate the 1.25 deprecation).

Once this and #21 are on main, rebasing #20 should make it fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)